### PR TITLE
lisence追加

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 KEN
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ run hometamon.py with busybox every 8 min.
 [褒めたもんについて（コンセプト編）](https://denden-seven.hatenablog.com/entry/2019/01/09/131220)  
 [褒めたもんについて（技術編）](https://denden-seven.hatenablog.com/entry/2019/01/09/130437)  
 
-## licence
-[MIT](https://github.com/tcnksm/tool/blob/master/LICENCE)
+## license
+[MIT](LICENSE)
 
 ## Author
 [seven320](https://github.com/seven320)


### PR DESCRIPTION
## WHY
READMEにあるlicenseリンクが無効になっています。そもそもLISENCEファイルがこのリポジトリ内に見当たりませんでした。

## WAHT
- `LICENSE`を追加
- RAEDMEのリンクを修正

現在名前を当てずっぽうで`KEN`としていますがこれで良かったでしょうか？ 
```
Copyright (c) 2020 KEN
```